### PR TITLE
Add fallback color for config.foregroundColor

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports.decorateConfig = config => {
       }
       ::-webkit-scrollbar-thumb {
         border-radius: 4px;
-        background-color:${config.foregroundColor};
+        background-color:${config.foregroundColor || 'rgba(255, 255, 255, 0.5)'};
       }
     `
   })


### PR DESCRIPTION
It may be the case that the variable won't have a value, and as such the CSS
produced will be

``` css
    background-color:undefined
```

Which results in a non-visible scrollbar. This PR adds a half-transparent white color as a default.

This happened to me with this config:

``` js
  plugins: [
    'hyperpower',
    'hypercwd',
    'opaque-cursor',
    'hyperterm-themed-scrollbar',
    'hyperterm-base16-ocean',
  ],
```

While having `config.foregroundColor` commented.
